### PR TITLE
property_types: add wof:population as integer type

### DIFF
--- a/property_types.json
+++ b/property_types.json
@@ -46,6 +46,7 @@
 	"wof:parent_id": "int",
 	"wof:placetype": "str",
 	"wof:placetype_alt": "list",
+	"wof:population": "int",
 	"wof:superseded_by": "list",
 	"wof:supersedes": "list",
 	"wof:tags": "list"


### PR DESCRIPTION
hey, I noticed the `wof:population` properties are being encoded as strings when they should probably be integers.